### PR TITLE
Add ability to specify which application directory and script to run

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Experiment 0: The obligatory "Hello, world!" example
+APP_DIR=apps/hello-world
+APP_SCRIPT=main.py
+
+# Experiment 1: Use a team of three agents to evaluate a proposed idea for a business and generate a business plan.
+# APP_DIR=apps/create-business-plan
+# APP_SCRIPT=main.py

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Our first (and so far only) example uses CrewAI to orchestrate three agents - a 
 
 This example was inspired by [Maya Akim](https://www.youtube.com/@maya-akim)'s video - [How I Made AI Assistants Do My Work For Me: CrewAI](https://www.youtube.com/watch?v=kJvXT25LkwA) - and significantly enhanced to reflect my tastes in implementing a modular design that is validated with unit tests.
 
-Please copy `apps/create-business-plan/.env.sample` to `apps/create-business-plan/.env` so you can supply a valid OpenAI API key and any other desired environment variables.
+Please copy `/.env.sample` to `/.env` to optionally specify a folder and initial file for the main script to run as well as copy `apps/create-business-plan/.env.sample` to `apps/create-business-plan/.env` so you can supply a valid OpenAI API key and any other desired environment variables.
 
 Once you've done that, let's take a look at the project-specific [README](./apps/create-business-plan/README.md)
 

--- a/apps/hello-world/main.py
+++ b/apps/hello-world/main.py
@@ -1,0 +1,1 @@
+print("\nHello, world!\n")

--- a/apps/hello-world/test_main.py
+++ b/apps/hello-world/test_main.py
@@ -1,0 +1,7 @@
+# apps/hello-world/test_main.py
+
+import subprocess
+
+def test_hello_world():
+    result = subprocess.run(["python3", "main.py"], capture_output=True, text=True)
+    assert result.stdout.strip() == "Hello, world!"

--- a/manage.sh
+++ b/manage.sh
@@ -3,9 +3,12 @@
 # Ensure the script exits if any command fails
 set -e
 
-# Check if APP_DIR and APP_SCRIPT environment variables are set; default to hello-world
-# APP_DIR="myappdir" APP_SCRIPT="myscript.py" ./manage.sh
+# Load environment variables from .env file if it exists
+if [ -f .env ]; then
+    export $(cat .env | grep -v '#' | awk '/=/ {print $1}')
+fi
 
+# Default to this application if no environment variables are provided
 # Experiment 1: Use a team of three agents to evaluate a proposed idea for a business and generate a business plan.
 : ${APP_DIR:="apps/create-business-plan"}
 : ${APP_SCRIPT:="main.py"}
@@ -39,7 +42,7 @@ setup_venv() {
     fi
 }
 
-# Function to start the FastAPI server
+# Function to start the application
 run_app() {
     # Ensure the virtual environment is set up
     setup_venv


### PR DESCRIPTION
The project will default to running Experiment 1 if the user has not specified a specific directory and initial script in a new top level .env file.